### PR TITLE
Add option to count adding cards

### DIFF
--- a/src/puppy_reinforcement/config.json
+++ b/src/puppy_reinforcement/config.json
@@ -7,6 +7,7 @@
     "limit_max": 100,
     "limit_high": 50,
     "limit_middle": 25,
+    "count_adding": false,
     "encouragements": {
         "low": ["Great job!", "Keep it up!", "Way to go!", "Keep up the good work!"],
         "middle": ["You're on a streak!", "You're crushing it!", "Don't stop now!",

--- a/src/puppy_reinforcement/config.md
+++ b/src/puppy_reinforcement/config.md
@@ -1,5 +1,6 @@
 **Puppy Reinforcement** supports the following config values:
 
+- `count_adding` [bool]: count adding notes as well; default: `false`
 - `duration` [int]: duration in msec; default: `3000`
 - `encourage_every` [int]: show encouragement about every n cards; default: `10`
 - `encouragements` [dict]: encouragements by level

--- a/src/puppy_reinforcement/main.py
+++ b/src/puppy_reinforcement/main.py
@@ -39,7 +39,8 @@ import random
 
 from aqt import mw
 from aqt.qt import *
-from anki.hooks import addHook
+from aqt.addcards import AddCards
+from anki.hooks import addHook, wrap
 
 from .config import config
 
@@ -134,4 +135,12 @@ def showDog():
                                         config["local"]["max_spread"]))
     mw.dogs["last"] = mw.dogs["cnt"]
 
+def myAddNote(self, note, _old):
+    ret = _old(self, note)
+    if ret:
+        showDog()
+    return ret
+
 addHook("showQuestion", showDog)
+if config["local"]["count_adding"]:
+    AddCards.addNote = wrap(AddCards.addNote, myAddNote, "around")


### PR DESCRIPTION
as requested in #12

#### Description
Adds an option to count adding cards the same as reviewing.
Default config does not count adding cards.

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Running Anki 2.1 from source: 844e90fc
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [ ] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bullseye
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
