### PR TITLE
Use the new "AddCards.noteAdded" hook

### DIFF
--- a/src/puppy_reinforcement/main.py
+++ b/src/puppy_reinforcement/main.py
@@ -40,7 +40,7 @@ import random
 from aqt import mw
 from aqt.qt import *
 from aqt.addcards import AddCards
-from anki.hooks import addHook, wrap
+from anki.hooks import addHook
 
 from .config import config
 
@@ -122,7 +122,7 @@ def getEncouragement(cards):
     mw.dogs["enc"] = lst[idx]
     return lst[idx]
 
-def showDog():
+def showDog(note=None):
     mw.dogs["cnt"] += 1
     if mw.dogs["cnt"] != mw.dogs["last"] + mw.dogs["ivl"]:
         return
@@ -135,12 +135,6 @@ def showDog():
                                         config["local"]["max_spread"]))
     mw.dogs["last"] = mw.dogs["cnt"]
 
-def myAddNote(self, note, _old):
-    ret = _old(self, note)
-    if ret:
-        showDog()
-    return ret
-
 addHook("showQuestion", showDog)
 if config["local"]["count_adding"]:
-    AddCards.addNote = wrap(AddCards.addNote, myAddNote, "around")
+    addHook("AddCards.noteAdded", showDog)


### PR DESCRIPTION
#### Description
Can't use this in a release before an Anki release including the new hook is out.

#### Checklist:

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [ ] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Running Anki 2.1 from source: ff7ff5c2b914f7a9c8689e9321e70fa13018f04f
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [ ] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bullseye
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
