### PR TITLE
Decrease count when reverting reviews.

### DIFF
--- a/src/puppy_reinforcement/reinforcer.py
+++ b/src/puppy_reinforcement/reinforcer.py
@@ -81,6 +81,10 @@ class PuppyReinforcer:
         )
         self._state["last"] = self._state["cnt"]
 
+    def undoReview(self, card_id):
+        """Decrease count when a review is reverted."""
+        self._state["cnt"] -= 1
+
     def _showTooltip(self, encouragement: str, image_path: str):
         config = self._config["local"]
         dogTooltip(

--- a/src/puppy_reinforcement/views.py
+++ b/src/puppy_reinforcement/views.py
@@ -30,7 +30,7 @@
 #
 # Any modifications to this file must keep this entire header intact.
 
-from anki.hooks import wrap
+from anki.hooks import addHook, wrap
 from aqt.addcards import AddCards
 from aqt.reviewer import Reviewer
 
@@ -42,9 +42,10 @@ from typing import Any
 
 def initializeViews(puppy_reinforcer: PuppyReinforcer):
     try:
-        from aqt.gui_hooks import reviewer_did_answer_card, add_cards_did_add_note
+        from aqt.gui_hooks import reviewer_did_answer_card, add_cards_did_add_note, review_did_undo
 
         reviewer_did_answer_card.append(puppy_reinforcer.showDog)
+        review_did_undo.append(puppy_reinforcer.undoReview)
         if config["local"]["count_adding"]:
             add_cards_did_add_note.append(puppy_reinforcer.showDog)
 
@@ -68,5 +69,6 @@ def initializeViews(puppy_reinforcer: PuppyReinforcer):
             return ret
 
         Reviewer._answerCard = wrap(Reviewer._answerCard, _myAnswerCard, "around")
+        addHook("revertedCard", puppy_reinforcer.undoReview)
         if config["local"]["count_adding"]:
             AddCards.addNote = wrap(AddCards.addNote, myAddNote, "around")


### PR DESCRIPTION
#### Description
Fixes #18.
Using the [review_did_undo](https://github.com/ankitects/anki/blob/master/qt/tools/genhooks_gui.py#L379) hook.
Didn't test the legacy hook.
#### Checklist:
- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Anki 2.1.24 running from source (9dcbb895)
- [ ] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bullseye
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
