### PR TITLE
Set notification timer to user duration

### DIFF
--- a/src/puppy_reinforcement/gui/notification.py
+++ b/src/puppy_reinforcement/gui/notification.py
@@ -97,11 +97,11 @@ class Notification(QLabel):
         Notification._current_instance = self
         if is_anki_version_in_range("2.1.54"):
             Notification._current_timer = self._progress_manager.timer(
-                3000, Notification._close_singleton, False, parent=self.parent()
+                self._duration, Notification._close_singleton, False, parent=self.parent()
             )
         else:
             Notification._current_timer = self._progress_manager.timer(
-                3000, Notification._close_singleton, False
+                self._duration, Notification._close_singleton, False
             )
 
     def mousePressEvent(self, evt: QMouseEvent):


### PR DESCRIPTION
#### Description

Closes #27

In all cases (old and new Anki versions), timers for "Notification" objects are created with a constant 3000 (ms) limit through a ProgressManager Qt widget. Yet, user configuration for notification duration is already retrieved in "_duration" attribute of "Notification" object. This commit reuses said attribute value to allow custom notification timer limit.

#### Checklist:

- [X] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [X] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [X] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons] (Anki 23.12.1)
  - [ ] Latest alternative Anki 2.1 binary build
- [X] I've tested my changes on at least one of the following platforms:
  - [X] Linux, version: Linux Mint 20.3
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
