### PR TITLE
Add GIF support and make images look better

### DIFF
--- a/src/puppy_reinforcement/reinforcer.py
+++ b/src/puppy_reinforcement/reinforcer.py
@@ -86,23 +86,16 @@ class PuppyReinforcer:
         )
         self._state["last"] = self._state["cnt"]
 
-    def _show_tooltip(self, encouragement: str, image_path: str):
+    def _show_tooltip(self, encouragement: str, media_path: str):
         local_config = self._config["local"]
         count = self._state["cnt"]
 
-        html = f"""\
-<table cellpadding=10>
-<tr>
-<td><img height={local_config["image_height"]} src="{image_path}"></td>
-<td valign="middle">
-    <center><b>{count} {'cards' if count > 1 else 'card'} done so far!</b><br>
-    {encouragement}</center>
-</td>
-</tr>
-</table>"""
+        text = f"<b>{count} {'cards' if count > 1 else 'card'} done so far!</b><br>{encouragement}"
 
         notification = Notification(
-            html,
+            text,
+            media_path,
+            local_config["image_height"],
             self._mw.progress,
             duration=local_config["duration"],
             parent=self._mw.app.activeWindow() or self._mw,


### PR DESCRIPTION
#### Description

Closes #2 and #20 by adding GIF support.

Refactors the Notification class to use native QPixmap, QMovie, and QHBoxLayout instead of HTML table.
- This allows support for GIFs (through QMovie), and opens the door to supporting other animated formats such as WEBM.
- Using QPixmap made it possible to specify `SmoothTransformation` to Qt, which uses bilinear filtering when scaling images. This addresses some of the discussion in #1 and makes images look better (reduces aliasing when downscaling).

This PR changes some variable names and some of the responsibilities and functions of the Notification class. Would welcome input on whether these changes align with the intention of how general the Notification class is supposed to be. Previously, it could display virtually anything since it was basically getting HTML from the caller. Now it must display media next to some text.

Here is a dog GIF that can be used to test the changes in this PR.
![dGxLYmh](https://github.com/glutanimate/puppy-reinforcement/assets/35200140/5f4eba01-220b-46c8-a399-3e5c36522965)

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version: Win10 22H2
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
